### PR TITLE
Auto authentication & proper logout redirect

### DIFF
--- a/CASClient.py
+++ b/CASClient.py
@@ -25,6 +25,13 @@ class CASClient:
 
     #-------------------------------------------------------------------
 
+    # Return True if user is logged in
+
+    def is_logged_in(self):
+        return "username" in session
+
+    #-------------------------------------------------------------------
+
     # Return the URL of the current request after stripping out the
     # "ticket" parameter added by the CAS server.
 	

--- a/CASClient.py
+++ b/CASClient.py
@@ -96,13 +96,10 @@ class CASClient:
     # Logout the user.
     
     def logout(self):
-        
         # Delete the user's username from the session.
-        session.pop('username')
-        
-        # Redirect the browser to the logout page.
-        logout_url = self.cas_url + 'logout'
-        abort(redirect(logout_url))
+        session.pop("username")
+        # Redirect the browser to the application's home page.
+        abort(redirect("/"))
         
 #-----------------------------------------------------------------------
 

--- a/routes.py
+++ b/routes.py
@@ -92,6 +92,9 @@ def get_reviews():
 
 @app.route("/")
 def index():
+    if CASClient().is_logged_in():
+        return redirect("/rooms")
+
     return make_response(render_template("index.html"))
 
 


### PR DESCRIPTION
## Changes

- If the user is already logged in when visiting `/`, automatically redirect to `/rooms`.
- Clicking logout now redirects users to `/` upon completion, rather than the default CAS "successfully logged out" page.